### PR TITLE
Upgrade sui version to latest mainnet-v1.49.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 FROM rust:1.81-bullseye AS builder
 RUN apt-get update && apt-get install -y cmake clang
 
-ARG VERSION=main
+ARG VERSION=mainnet-v1.49.2
 RUN git clone --depth=1 --branch ${VERSION} https://github.com/MystenLabs/sui
 WORKDIR /sui
 


### PR DESCRIPTION
The old `sui` version fails in `sui move test`: see [#47](https://github.com/zeta-chain/protocol-contracts-sui/issues/47)
Switch to the latest sui mainnet version `mainnet-v1.49.2` to fix unit test failures.